### PR TITLE
Fix double line issue

### DIFF
--- a/android/src/main/java/leesiongchan/reactnativeescpos/PrinterService.java
+++ b/android/src/main/java/leesiongchan/reactnativeescpos/PrinterService.java
@@ -225,16 +225,16 @@ public class PrinterService {
             }
             if (h1) {
                 baos.write(TXT_4SQUARE_NEW);
-                baos.write(LINE_SPACE_88);
+                // baos.write(LINE_SPACE_88);
                 line = line.replace("{H1}", "");
                 charsOnLine = charsOnLine / 2;
             } else if (h2) {
                 baos.write(TXT_2HEIGHT_NEW);
-                baos.write(LINE_SPACE_88);
+                // baos.write(LINE_SPACE_88);
                 line = line.replace("{H2}", "");
             } else if (h3) {
                 baos.write(TXT_2WIDTH_NEW);
-                baos.write(LINE_SPACE_68);
+                // baos.write(LINE_SPACE_68);
                 line = line.replace("{H3}", "");
                 charsOnLine = charsOnLine / 2;
             }


### PR DESCRIPTION
Tested on 3 types of printer printing english and chinese. 
No more double line spacing after removed the LINE_SPACE_88 and LINE_SPACE_68