### PR TITLE
Add IMG Tag, Fix RP Tag, Fix centered QR and IMG

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ D0004           {<>}           Table #: A1
                               {H3} {R} x 1
 
 {QR[Where are the aliens?]}
+{IMG[file://image/path/file.png]}
 `;
 
 async function testPrinter() {
@@ -142,6 +143,7 @@ EscPos.addListener("bluetoothDeviceFound", (event: any) => {
 | {R}      | Align text to right.                          |
 | {RP:?:?} | Repeat text. Eg. {RP:5:a} will output "aaaaa" |
 | {QR[?]}  | Print QR code.                                |
+| {IMG[?]} | Print image from a path.                      |
 | {<>}     | Left-right text separation.                   |
 | {---}    | Create a "---" separator.                     |
 | {===}    | Create a "===" separator.                     |
@@ -187,8 +189,15 @@ Device MAC Address:
 > Example:
 > Input: {RP:3:= }This is a test string{RP:2:@_@}
 > Output: = = = This is a test string@_@@\_@
-
+>
+> Example 2:
+> Input: {RP:3:-}This is a test string{RP:3:-}
+> Output: ---This is a test string---
+>
 > Important note: this feature does not support repetitive printing of Closing Curly Bracket }.
+
+- Print to 76mm Printer (Experimental)
+
 
 ## TODO
 

--- a/android/src/main/java/leesiongchan/reactnativeescpos/BluetoothPrinter.java
+++ b/android/src/main/java/leesiongchan/reactnativeescpos/BluetoothPrinter.java
@@ -1,5 +1,6 @@
 package leesiongchan.reactnativeescpos;
 
+import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothSocket;
@@ -24,7 +25,7 @@ public class BluetoothPrinter implements Printer {
 
     public void open() throws IOException {
         BluetoothDevice device = adapter.getRemoteDevice(address);
-        BluetoothSocket socket = device.createRfcommSocketToServiceRecord(SPP_UUID);
+        @SuppressLint("MissingPermission") BluetoothSocket socket = device.createRfcommSocketToServiceRecord(SPP_UUID);
         socket.connect();
         printer = socket.getOutputStream();
     }

--- a/android/src/main/java/leesiongchan/reactnativeescpos/EscPosModule.java
+++ b/android/src/main/java/leesiongchan/reactnativeescpos/EscPosModule.java
@@ -52,7 +52,6 @@ public class EscPosModule extends ReactContextBaseJavaModule {
         super(reactContext);
         this.reactContext = reactContext;
         scanManager = new ScanManager(reactContext, BluetoothAdapter.getDefaultAdapter());
-        System.out.println("Injected!");
     }
 
     @Override

--- a/android/src/main/java/leesiongchan/reactnativeescpos/EscPosModule.java
+++ b/android/src/main/java/leesiongchan/reactnativeescpos/EscPosModule.java
@@ -7,6 +7,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 
+import androidx.annotation.RequiresPermission;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -32,6 +34,7 @@ import static io.github.escposjava.print.Commands.*;
 
 public class EscPosModule extends ReactContextBaseJavaModule {
     public static final String PRINTING_SIZE_58_MM = "PRINTING_SIZE_58_MM";
+    public static final String PRINTING_SIZE_76_MM = "PRINTING_SIZE_76_MM";
     public static final String PRINTING_SIZE_80_MM = "PRINTING_SIZE_80_MM";
     public static final String BLUETOOTH_CONNECTED = "BLUETOOTH_CONNECTED";
     public static final String BLUETOOTH_DISCONNECTED = "BLUETOOTH_DISCONNECTED";
@@ -48,14 +51,15 @@ public class EscPosModule extends ReactContextBaseJavaModule {
     public EscPosModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
-
         scanManager = new ScanManager(reactContext, BluetoothAdapter.getDefaultAdapter());
+        System.out.println("Injected!");
     }
 
     @Override
     public Map<String, Object> getConstants() {
         final Map<String, Object> constants = new HashMap<>();
         constants.put(PRINTING_SIZE_58_MM, PRINTING_SIZE_58_MM);
+        constants.put(PRINTING_SIZE_76_MM, PRINTING_SIZE_76_MM);
         constants.put(PRINTING_SIZE_80_MM, PRINTING_SIZE_80_MM);
         constants.put(BLUETOOTH_CONNECTED, BluetoothEvent.CONNECTED.name());
         constants.put(BLUETOOTH_DISCONNECTED, BluetoothEvent.DISCONNECTED.name());
@@ -178,15 +182,20 @@ public class EscPosModule extends ReactContextBaseJavaModule {
         int printingWidth;
 
         switch (printingSize) {
-        case PRINTING_SIZE_80_MM:
-            charsOnLine = LayoutBuilder.CHARS_ON_LINE_80_MM;
-            printingWidth = PrinterService.PRINTING_WIDTH_80_MM;
-            break;
+            case PRINTING_SIZE_80_MM:
+                charsOnLine = LayoutBuilder.CHARS_ON_LINE_80_MM;
+                printingWidth = PrinterService.PRINTING_WIDTH_80_MM;
+                break;
 
-        case PRINTING_SIZE_58_MM:
-        default:
-            charsOnLine = LayoutBuilder.CHARS_ON_LINE_58_MM;
-            printingWidth = PrinterService.PRINTING_WIDTH_58_MM;
+            case PRINTING_SIZE_76_MM:
+                charsOnLine = LayoutBuilder.CHARS_ON_LINE_76_MM;
+                printingWidth = PrinterService.PRINTING_WIDTH_76_MM;
+                break;
+
+            case PRINTING_SIZE_58_MM:
+            default:
+                charsOnLine = LayoutBuilder.CHARS_ON_LINE_58_MM;
+                printingWidth = PrinterService.PRINTING_WIDTH_58_MM;
         }
 
         printerService.setCharsOnLine(charsOnLine);
@@ -224,6 +233,7 @@ public class EscPosModule extends ReactContextBaseJavaModule {
             }
             Printer printer = new BluetoothPrinter(address);
             printerService = new PrinterService(printer);
+            printerService.setContext(reactContext);
             promise.resolve(true);
         } catch (IOException e) {
             promise.reject(e);
@@ -238,6 +248,7 @@ public class EscPosModule extends ReactContextBaseJavaModule {
             }
             Printer printer = new NetworkPrinter(address, port);
             printerService = new PrinterService(printer);
+            printerService.setContext(reactContext);
             promise.resolve(true);
         } catch (IOException e) {
             promise.reject(e);
@@ -254,6 +265,7 @@ public class EscPosModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @SuppressWarnings({"MissingPermission"})
     @ReactMethod
     public void scanDevices() {
         scanManager.registerCallback(new ScanManager.OnBluetoothScanListener() {
@@ -295,6 +307,7 @@ public class EscPosModule extends ReactContextBaseJavaModule {
     /**
      * Bluetooth Connection Event Listener
      */
+    @SuppressWarnings({"MissingPermission"})
     private BroadcastReceiver bluetoothConnectionEventListener = new BroadcastReceiver() {
         public void onReceive(Context context, Intent intent) {
             String callbackAction = intent.getAction();
@@ -310,16 +323,16 @@ public class EscPosModule extends ReactContextBaseJavaModule {
             BluetoothEvent bluetoothEvent;
 
             switch (callbackAction) {
-            case BluetoothDevice.ACTION_ACL_CONNECTED:
-                bluetoothEvent = BluetoothEvent.CONNECTED;
-                break;
+                case BluetoothDevice.ACTION_ACL_CONNECTED:
+                    bluetoothEvent = BluetoothEvent.CONNECTED;
+                    break;
 
-            case BluetoothDevice.ACTION_ACL_DISCONNECTED:
-                bluetoothEvent = BluetoothEvent.DISCONNECTED;
-                break;
+                case BluetoothDevice.ACTION_ACL_DISCONNECTED:
+                    bluetoothEvent = BluetoothEvent.DISCONNECTED;
+                    break;
 
-            default:
-                bluetoothEvent = BluetoothEvent.NONE;
+                default:
+                    bluetoothEvent = BluetoothEvent.NONE;
             }
 
             // bluetooth event must not be null

--- a/android/src/main/java/leesiongchan/reactnativeescpos/LayoutBuilder.java
+++ b/android/src/main/java/leesiongchan/reactnativeescpos/LayoutBuilder.java
@@ -17,6 +17,7 @@ public class LayoutBuilder {
     public static final String TEXT_ALIGNMENT_CENTER = "CENTER";
     public static final String TEXT_ALIGNMENT_RIGHT = "RIGHT";
     public static final int CHARS_ON_LINE_58_MM = 32;
+    public static final int CHARS_ON_LINE_76_MM = 42;
     public static final int CHARS_ON_LINE_80_MM = 48;
     private int charsOnLine = CHARS_ON_LINE_58_MM;
 
@@ -130,14 +131,14 @@ public class LayoutBuilder {
         }
 
         switch (alignment) {
-        case TEXT_ALIGNMENT_RIGHT:
-            return StringUtils.leftPad(text, charsOnLine, space) + "\n";
+            case TEXT_ALIGNMENT_RIGHT:
+                return StringUtils.leftPad(text, charsOnLine, space) + "\n";
 
-        case TEXT_ALIGNMENT_CENTER:
-            return StringUtils.center(text, charsOnLine, space) + "\n";
+            case TEXT_ALIGNMENT_CENTER:
+                return StringUtils.center(text, charsOnLine, space) + "\n";
 
-        default:
-            return StringUtils.rightPad(text, charsOnLine, space) + "\n";
+            default:
+                return StringUtils.rightPad(text, charsOnLine, space) + "\n";
         }
     }
 
@@ -145,22 +146,22 @@ public class LayoutBuilder {
         String repeatTag = "{RP:";
         String regex = "\\"+repeatTag+"\\d+:.*?\\}";
         Matcher m = Pattern.compile(regex).matcher(text);
-        int tagCount = 0;	
-		while(m.find()){
-			tagCount++;
+        int tagCount = 0;
+        while(m.find()){
+            tagCount++;
         }
-        
+
         for(int x = 0; x < tagCount; x++){
             String symbol = "", count = "0", repeatedSymbol = "";
             int rpIndex = text.indexOf(repeatTag);
             String workingString = text.substring(rpIndex+(repeatTag.length()), text.indexOf('}'));
-			int separatorIdx = workingString.indexOf(':');
-	        count = workingString.substring(0,separatorIdx);
+            int separatorIdx = workingString.indexOf(':');
+            count = workingString.substring(0,separatorIdx);
             symbol = workingString.substring(separatorIdx+1, workingString.length());
             repeatedSymbol = StringUtils.repeat(symbol, Integer.parseInt(count));
 
             String replaceRepeatTag = repeatTag + workingString + "}";
-            text = text.replace(text.substring(text.indexOf(replaceRepeatTag),text.indexOf(replaceRepeatTag)+replaceRepeatTag.length()), repeatedSymbol);
+            text = text.replaceFirst(Pattern.quote(text.substring(text.indexOf(replaceRepeatTag),text.indexOf(replaceRepeatTag)+replaceRepeatTag.length())), Matcher.quoteReplacement(repeatedSymbol));
         }
 
         return text + "\n";

--- a/android/src/main/java/leesiongchan/reactnativeescpos/LayoutBuilderModule.java
+++ b/android/src/main/java/leesiongchan/reactnativeescpos/LayoutBuilderModule.java
@@ -71,13 +71,17 @@ public class LayoutBuilderModule extends ReactContextBaseJavaModule {
         int charsOnLine;
 
         switch (printingSize) {
-        case EscPosModule.PRINTING_SIZE_80_MM:
-            charsOnLine = LayoutBuilder.CHARS_ON_LINE_80_MM;
-            break;
+            case EscPosModule.PRINTING_SIZE_80_MM:
+                charsOnLine = LayoutBuilder.CHARS_ON_LINE_80_MM;
+                break;
 
-        case EscPosModule.PRINTING_SIZE_58_MM:
-        default:
-            charsOnLine = LayoutBuilder.CHARS_ON_LINE_58_MM;
+            case EscPosModule.PRINTING_SIZE_76_MM:
+                charsOnLine = LayoutBuilder.CHARS_ON_LINE_76_MM;
+                break;
+
+            case EscPosModule.PRINTING_SIZE_58_MM:
+            default:
+                charsOnLine = LayoutBuilder.CHARS_ON_LINE_58_MM;
         }
 
         layoutBuilder.setCharsOnLine(charsOnLine);

--- a/android/src/main/java/leesiongchan/reactnativeescpos/PrinterService.java
+++ b/android/src/main/java/leesiongchan/reactnativeescpos/PrinterService.java
@@ -109,7 +109,6 @@ public class PrinterService {
         BitmapFactory.Options op = new BitmapFactory.Options();
         op.inPreferredConfig = Bitmap.Config.ARGB_8888;
         image = BitmapFactory.decodeFile(fileUri.getPath(), op);
-        System.out.println(filePath);
         return image;
     }
 

--- a/android/src/main/java/leesiongchan/reactnativeescpos/helpers/EscPosHelper.java
+++ b/android/src/main/java/leesiongchan/reactnativeescpos/helpers/EscPosHelper.java
@@ -1,6 +1,10 @@
 package leesiongchan.reactnativeescpos.helpers;
 
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ImageDecoder;
+import android.graphics.Paint;
 
 import java.io.ByteArrayOutputStream;
 
@@ -14,6 +18,7 @@ public class EscPosHelper {
      * @param image 2D array of pixels of the image (RGB, row major order).
      * @return 3 byte array with 24 dots (field set).
      */
+
     public static byte[] collectImageSlice(int y, int x, Bitmap image) {
         byte[] slices = new byte[] { 0, 0, 0 };
         for (int yy = y, i = 0; yy < y + 24 && i < 3; yy += 8, i++) { // repeat for 3 cycles
@@ -35,7 +40,7 @@ public class EscPosHelper {
 
     /**
      * Resizes a Bitmap image.
-     * 
+     *
      * @param image
      * @param width
      * @return new Bitmap image.
@@ -55,6 +60,25 @@ public class EscPosHelper {
             return newImage;
         }
 
+        return image;
+    }
+
+    public static Bitmap resizeImage(Bitmap image, int maxWidth, int maxHeight) {
+        if (maxHeight > 0 && maxWidth > 0) {
+            int width = image.getWidth();
+            int height = image.getHeight();
+            float ratioBitmap = (float) width / (float) height;
+            float ratioMax = (float) maxWidth / (float) maxHeight;
+
+            int finalWidth = maxWidth;
+            int finalHeight = maxHeight;
+            if (ratioMax > ratioBitmap) {
+                finalWidth = (int) ((float)maxHeight * ratioBitmap);
+            } else {
+                finalHeight = (int) ((float)maxWidth / ratioBitmap);
+            }
+            image = Bitmap.createScaledBitmap(image, finalWidth, finalHeight, true);
+        }
         return image;
     }
 


### PR DESCRIPTION
**What it is?**

- Add IMG tag so now it can print an image using command inside the design instead of using the API method,
  the syntax is ```{IMG[file://image/path/file.png]}```
- Fix the QR and IMG TAG so it can be mixed with other TAG in one line in design, eg:
  ```{QR[data]}{C}``` will print the QR Code centered
  ```{IMG[file://image/path/file.png]}{C}``` will print the Image centered
- Try to implement printer width 76
- Convert image to RGBA_565 during reading
- Fix the issue that causes can not have more than one same {RP:n:*} tag in one line
  eg: previously this will cause error ```{RP:5:-}Some Text{RP:5:-}``` 
  since the replacer routine will replace both RP tag, but then try to replace it again in next iteration
- Replace image resizer static method so it can retain aspect ratio while can have max-width or max-height
- Put some lint suppressor to prevent IDE to reporting error due to lack of Bluetooth permission in the manifest

**Suggestion:**

- Need a way to freely customize printed QR and IMG size 